### PR TITLE
Migrate CLI interface to typer library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,11 +114,10 @@ typehints = ["typing", "typing_extensions", "types", "collections.abc"]
 
 [tool.ruff.per-file-ignores]
 # Allow print statements in CLI interface
-"src/icespeak/cli.py" = ["T201"]
+"src/icespeak/cli.py" = ["FBT001", "FBT002"]
 
 [project.optional-dependencies]
-# Dependencies needed to parse text for more in-depth transcribing
-parsing = ["tokenizer", "reynir", "islenska"]
+cli = ["typer[all]==0.9.0"]
 # Dev dependencies
 dev = [
     "pytest>=7.2.1",

--- a/src/icespeak/cli.py
+++ b/src/icespeak/cli.py
@@ -25,7 +25,8 @@
         tts --help
 
 """
-
+# TODO: Transcribe-only option
+# TODO: Add separate progress bar for transcription phase
 from typing import Annotated, Optional
 
 import shutil
@@ -83,6 +84,9 @@ def _play_audio_file(path: Path, player: Optional[str] = None) -> None:
     elif mpg123 := shutil.which("mpg123"):
         # mpg123 is a cross-platform player
         cmd = [mpg123, "--quiet"]
+    elif vlc := shutil.which("vlc"):
+        # vlc is a cross-platform player
+        cmd = [vlc]
     elif cmdmp3 := shutil.which("cmdmp3"):
         # cmdmp3 is a Windows command line mp3 player
         cmd = [cmdmp3]
@@ -237,9 +241,6 @@ def _text_to_speech(
         TextColumn("[progress.description]{task.description}"),
         transient=True,
     ) as progress:
-        # TODO: Split tts_to_file into transcribe phase and tts phase
-        # progress.add_task("Transcribing text...", total=None)
-        # transcribed = transcribe(...)
         progress.add_task("Synthesizing text...", total=None)
         # Synthesize the text according to CLI options
         tts_out = tts_to_file(

--- a/src/icespeak/cli.py
+++ b/src/icespeak/cli.py
@@ -25,257 +25,256 @@
         tts --help
 
 """
-from __future__ import annotations
 
-import string
+from typing import Annotated, Optional
+
+import shutil
 import subprocess
 import sys
 import wave
 from pathlib import Path
-from shutil import which
-from urllib.request import urlopen
 
-import requests
+_TYPER_MISSING = """
+To use the command line tool install icespeak with the 'cli' optional dependency:
+    python3 -m pip install 'icespeak[cli]'
+"""
 
-from .settings import LOG, SETTINGS, suffix_for_audiofmt
+try:
+    import typer
+    from rich import print
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.table import Table
+except ModuleNotFoundError:
+    print(_TYPER_MISSING, file=sys.stderr)
+    sys.exit(1)
+
+from .settings import SETTINGS, AudioFormats, TextFormats
 from .tts import VOICES, TTSOptions, tts_to_file
 
 
-def _die(msg: str, exit_code: int = 1) -> None:
-    print(msg, file=sys.stderr)
-    sys.exit(exit_code)
-
-
-_DATA_URI_PREFIX = "data:"
-
-
-def _is_data_uri(s: str) -> bool:
-    """Returns whether a URL is a data URI (RFC2397). Tolerates upper/mixed case prefix."""
-    return s[: len(_DATA_URI_PREFIX)].lower() == _DATA_URI_PREFIX
-
-
-def _is_file_uri(s: str) -> bool:
-    """Returns whether a URL is a file URI (RFC8089)."""
-    return s.startswith("file://")
-
-
-def _bytes4file_or_data_uri(uri: str) -> bytes:
-    """Returns bytes of file at file URI (RFC8089) or in data URI (RFC2397)."""
-    with urlopen(uri) as response:  # noqa: S310
-        return response.read()
-
-
-def _sanitize_filename(fn: str, maxlen: int = 60) -> str:
-    """Sanitize a potential filename string by limiting allowed characters."""
-
-    ALLOWED_FILE_CHARS = string.ascii_letters + string.digits + "._-"
-
-    # Replace whitespace with dash
-    fn = "-".join([t for t in fn.lower().split()])
-
-    # Rm non-ASCII chars, non-filename chars and limit length
-    fn = "".join(c if c in ALLOWED_FILE_CHARS else "_" for c in fn)[:maxlen].rstrip(
-        "._"
-    )
-
-    return fn
-
-
-def _fetch_audio_bytes(url: str) -> bytes | None:
-    """Returns bytes of audio file at URL."""
-    if _is_data_uri(url) or _is_file_uri(url):
-        return _bytes4file_or_data_uri(url)
-
-    try:
-        r = requests.get(url, timeout=10)
-        if r.status_code != 200:
-            raise Exception(
-                f"Received HTTP status code {r.status_code} when fetching {url}"
-            )
-        return r.content
-    except Exception:
-        LOG.exception("Error fetching audio file.")
-
-
 def _write_wav(
-    fn: str,
+    fn: Path,
     data: bytes,
     num_channels: int = 1,
     sample_width: int = 2,
     sample_rate: int = 16000,
 ) -> None:
     """Write audio data to WAV file. Defaults to 16-bit mono 16 kHz PCM."""
-    with wave.open(fn, "wb") as wav:
+    with wave.open(str(fn), "wb") as wav:
         wav.setnchannels(num_channels)
         wav.setsampwidth(sample_width)
         wav.setframerate(sample_rate)
         wav.writeframes(data)
 
 
-def _play_audio_file(path: str) -> None:
+def _play_audio_file(path: Path, player: Optional[str] = None) -> None:
     """Play audio file at path via command line player. This only works
     on systems with afplay (macOS), mpv, mpg123 or cmdmp3 installed."""
 
-    afplay = "/usr/bin/afplay"  # afplay is only present on macOS systems
-    mpv = which("mpv")  # mpv is a cross-platform player
-    mpg123 = which("mpg123")  # mpg123 is a cross-platform player
-    cmdmp3 = which("cmdmp3")  # cmdmp3 is a Windows command line mp3 player
-
-    cmd: list[str] | None = None
-    if Path(afplay).is_file():
-        cmd = [afplay, path]
-    elif mpv:
-        cmd = [mpv, path]
-    elif mpg123:
-        cmd = [mpg123, "--quiet", path]
-    elif cmdmp3:
-        cmd = [cmdmp3, path]
+    cmd: list[str] = []
+    if player and (custom := shutil.which(player)):
+        cmd = [custom]
+    elif afplay := shutil.which("afplay"):
+        # afplay is only present on macOS systems
+        cmd = [afplay]
+    elif mpv := shutil.which("mpv"):
+        # mpv is a cross-platform player
+        cmd = [mpv]
+    elif mpg123 := shutil.which("mpg123"):
+        # mpg123 is a cross-platform player
+        cmd = [mpg123, "--quiet"]
+    elif cmdmp3 := shutil.which("cmdmp3"):
+        # cmdmp3 is a Windows command line mp3 player
+        cmd = [cmdmp3]
 
     if not cmd:
-        _die("Couldn't find suitable command line audio player.")
-    else:
-        print(f"Playing file '{path}'")
-        subprocess.run(cmd)  # noqa: S603
+        print("No CLI audio player found.", file=sys.stderr)
+        raise typer.Exit(1)
+
+    cmd.append(str(path))
+    print(f"Playing file '{path}'")
+    subprocess.run(cmd)  # noqa: S603
 
 
-DEFAULT_TEXT = ["Góðan daginn og til hamingju með lífið."]
+DEFAULT_TEXT = "Góðan daginn og til hamingju með lífið."
 
 
-def main() -> None:
-    """Main program function."""
-    from argparse import ArgumentParser
+def _check_voice(voice: str) -> str:
+    if voice not in VOICES:
+        raise typer.BadParameter(f"Voice {voice!r} is not an available voice.")
+    return voice
 
-    parser = ArgumentParser()
 
-    parser.add_argument(
-        "-v",
-        "--voice",
-        help="specify which voice to use",
-        default=SETTINGS.DEFAULT_VOICE,
-        choices=list(VOICES.keys()),
-    )
-    parser.add_argument(
-        "-l",
-        "--list-voices",
-        help="print list of supported voices",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-f",
-        "--audioformat",
-        help="select audio format",
-        default=SETTINGS.DEFAULT_AUDIO_FORMAT,
-    )
-    parser.add_argument(
-        "-s",
-        "--speed",
-        help="set speech speed",
-        default=1.0,
-        type=float,
-    )
-    parser.add_argument(
-        "-t",
-        "--textformat",
-        help="set text format",
-        default=SETTINGS.DEFAULT_TEXT_FORMAT,
-        choices=["text", "ssml"],
-    )
-    parser.add_argument(
-        "-o",
-        "--override",
-        help="override default audio output filename",
-        default="",  # Empty string means use default filename
-    )
-    parser.add_argument(
-        "-w", "--wav", help="generate WAV file from PCM", action="store_true"
-    )
-    parser.add_argument(
-        "-u", "--url", help="dump audio URL to stdout", action="store_true"
-    )
-    parser.add_argument(
-        "-n", "--noplay", help="do not play resulting audio file", action="store_true"
-    )
-    parser.add_argument(
-        "-r", "--remove", help="remove audio file after playing", action="store_true"
-    )
-    parser.add_argument(
-        "text",
-        help="text to synthesize",
-        nargs="*",
-        default=DEFAULT_TEXT,
-    )
+def _list_voices(run: bool):
+    """Print available voices in a table"""
+    if run:
+        voice_table = Table()
+        voice_table.add_column("Voice")
+        voice_table.add_column("Language/Locale")
+        voice_table.add_column("Style")
+        voice_table.add_column("Service")
+        for voice, info in VOICES.items():
+            voice_table.add_row(
+                voice, info["lang"], info["style"], info.get("service", "N/A")
+            )
+        print(voice_table)
+        raise typer.Exit(0)
 
-    args = parser.parse_args()
 
-    if args.list_voices:
-        for voice in VOICES:
-            print(voice)
-        sys.exit(0)
-
-    if len(args.text) == 0:
-        _die("No text provided.")
-    text = " ".join(args.text).strip()
-    if len(text) == 0:
-        _die("No text provided.")
-
-    if args.wav and args.audioformat != "pcm":
-        _die("WAV output flag only supported for PCM format.")
-
-    # Synthesize the text according to CLI options
-    tts_out = tts_to_file(
-        text,
-        TTSOptions(
-            text_format=args.textformat,
-            audio_format=args.audioformat,
-            voice=args.voice,
-            speed=args.speed,
+def _text_to_speech(
+    text: Annotated[str, typer.Argument(help="Input text.")] = DEFAULT_TEXT,
+    file: Annotated[
+        Optional[Path],
+        typer.Option("--file", "-f", help="Read input text from file instead."),
+    ] = None,
+    # TTS options
+    voice: Annotated[
+        str, typer.Option("--voice", "-v", callback=_check_voice, help="TTS voice.")
+    ] = SETTINGS.DEFAULT_VOICE,
+    speed: Annotated[
+        float, typer.Option("--speed", "-s", min=0.5, max=2.0, help="TTS speed.")
+    ] = SETTINGS.DEFAULT_VOICE_SPEED,
+    text_format: Annotated[
+        TextFormats, typer.Option(help="Input text format.")
+    ] = SETTINGS.DEFAULT_TEXT_FORMAT,
+    # Transcription options
+    transcribe: Annotated[
+        bool,
+        typer.Option(
+            "--transcribe/--no-transcribe",
+            "-t/-T",
+            help="Transcribe Icelandic text before TTS.",
         ),
-    )
-    url = tts_out.file.as_uri()
-    if not url:
-        _die("Error synthesizing speech.")
+    ] = True,
+    # Audio options
+    play: Annotated[
+        bool,
+        typer.Option(
+            help="Play output audio via CLI audio player.",
+        ),
+    ] = True,
+    player: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Audio player application.",
+        ),
+    ] = None,
+    # Output file options
+    out: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--out",
+            "-o",
+            help="Output file to save audio to (by default the output file isn't kept).",
+        ),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option(
+            help="Force writing to output file.",
+        ),
+    ] = False,
+    audio_format: Annotated[
+        AudioFormats, typer.Option(help="Output audio format.")
+    ] = SETTINGS.DEFAULT_AUDIO_FORMAT,
+    wav: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--wav",
+            help="Write PCM output audio in WAV format.",
+        ),
+    ] = False,
+    # Util
+    list_voices: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--list-voices",
+            callback=_list_voices,
+            is_eager=True,
+            help="List the available voices and exit.",
+        ),
+    ] = False,
+) -> None:
+    """
+    Command line interface to icespeak.
 
-    # Command line flag specifies that we should just dump the URL to stdout
-    if args.url:
-        print(url)
-        sys.exit(0)
+    Provides text-to-speech, transcription of Icelandic text
+    and playing synthesized speech.
+    """
+    if file:
+        if text != DEFAULT_TEXT:
+            raise typer.BadParameter("Don't specify both text and --file.")
+        if not file.is_file():
+            raise typer.BadParameter(f"File {file} missing/invalid.")
+        text = file.read_text()
 
-    # TODO: This isn't needed anymore
-    # Download
-    urldesc = f"data URI ({len(url)} bytes)" if _is_data_uri(url) else url
-    print(f"Fetching {urldesc}")
-    data: bytes | None = _fetch_audio_bytes(url)
-    if not data:
-        _die("Unable to fetch audio data.")
+    if out and out.exists() and not force:
+        # Outfile exists, no --force parameter specified
+        raise typer.BadParameter(
+            f"File {out} already exists! Specify --force to overwrite."
+        )
+    if force and out and out.is_dir():
+        raise typer.BadParameter(f"Cannot overwrite directory {out}.")
+    if wav and audio_format != AudioFormats.PCM:
+        raise typer.BadParameter(
+            'When --wav is specified, --audio-format must be "pcm".'
+        )
+    if audio_format != SETTINGS.DEFAULT_AUDIO_FORMAT and not out:
+        # When asking for specific audio format an output file must be specified
+        # We're assuming that the user wants to keep the audio file,
+        # because without --out icespeak simply removes the file.
+        raise typer.BadParameter(
+            "Specify --out file if specifying --audio-format or --wav."
+        )
+    if transcribe and VOICES[voice]["lang"] != "is-IS":
+        transcribe = False
+        print("Transcription disabled, as the voice isn't Icelandic.", file=sys.stderr)
 
-    assert data is not None  # Silence typing complaints
+    # Finished validating arguments
 
-    if args.override:
-        # Override default filename
-        fn = args.override
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        # TODO: Split tts_to_file into transcribe phase and tts phase
+        # progress.add_task("Transcribing text...", total=None)
+        # transcribed = transcribe(...)
+        progress.add_task("Synthesizing text...", total=None)
+        # Synthesize the text according to CLI options
+        tts_out = tts_to_file(
+            text,
+            TTSOptions(
+                text_format=text_format,
+                audio_format=audio_format,
+                voice=voice,
+                speed=speed,
+            ),
+            transcribe=transcribe,
+        )
+
+    # Finished transcribing and synthesizing speech
+
+    if out:
+        if wav:
+            # Rewrite file in WAV format
+            _write_wav(out, tts_out.file.read_bytes())
+        else:
+            # Otherwise simply copy the file
+            # (or move, doesn't matter, icespeak cleans up)
+            shutil.copy(tts_out.file, out)
     else:
-        # Generate file name
-        fn = _sanitize_filename(text)
-        fn = f"{fn}.{suffix_for_audiofmt(args.audioformat)}"
+        out = tts_out.file
 
-    # Write audio data to file
-    print(f'Writing to file "{fn}".')
-    if args.wav:
-        _write_wav(fn, data)
-    else:
-        with open(fn, "wb") as f:
-            f.write(data)
+    # Play audio
 
-    # Play audio file using command line tool (if available)
-    if not args.noplay:
-        _play_audio_file(fn)
+    if play:
+        _play_audio_file(out, player)
 
-    # Remove file after playing
-    if args.remove:
-        print(f'Deleting file "{fn}".')
-        Path(fn).unlink()
+
+def main():
+    typer.run(_text_to_speech)
 
 
 if __name__ == "__main__":
-    """Perform speech synthesis of Icelandic text via the command line."""
     main()

--- a/src/icespeak/settings.py
+++ b/src/icespeak/settings.py
@@ -22,11 +22,12 @@
 """
 # We dont import annotations from __future__ here
 # due to pydantic
-from typing import Any, Literal, Optional, Union
+from typing import Any, Optional, Union
 
 import json
 import tempfile
 import uuid
+from enum import Enum
 from logging import getLogger
 from pathlib import Path
 
@@ -37,12 +38,23 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 __logger__ = "icespeak"
 LOG = getLogger(__logger__)
 
+
 # For details about SSML markup, see:
 # https://developer.amazon.com/en-US/docs/alexa/custom-skills/speech-synthesis-markup-language-ssml-reference.html
 # or:
 # https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup
-TextFormatsT = Literal["ssml", "text"]
-AudioFormatsT = Literal["mp3", "ogg_vorbis", "pcm", "opus"]
+class TextFormats(str, Enum):
+    SSML = "ssml"
+    TEXT = "text"
+
+
+class AudioFormats(str, Enum):
+    MP3 = "mp3"
+    OGG_VORBIS = "ogg_vorbis"
+    PCM = "pcm"
+    OPUS = "opus"
+
+
 MAX_SPEED = 2.0
 MIN_SPEED = 0.5
 
@@ -74,12 +86,12 @@ class Settings(BaseSettings):
         default="Gudrun", description="Default TTS voice if none is requested."
     )
     DEFAULT_VOICE_SPEED: float = Field(default=1.0, le=MAX_SPEED, ge=MIN_SPEED)
-    DEFAULT_TEXT_FORMAT: TextFormatsT = Field(
-        default="ssml",
+    DEFAULT_TEXT_FORMAT: TextFormats = Field(
+        default=TextFormats.SSML,
         description="Default format to interpret input text as.",
     )
-    DEFAULT_AUDIO_FORMAT: AudioFormatsT = Field(
-        default="mp3", description="Default audio output format."
+    DEFAULT_AUDIO_FORMAT: AudioFormats = Field(
+        default=AudioFormats.MP3, description="Default audio output format."
     )
 
     AUDIO_DIR: Optional[Path] = Field(
@@ -172,13 +184,14 @@ _kd = SETTINGS.KEYS_DIR
 if not (_kd.exists() and _kd.is_dir()):
     LOG.warning("Keys directory missing or incorrect, TTS will not work!")
 else:
-    # Load API keys
+    # Load API keys, logging exceptions in level DEBUG so they aren't logged twice,
+    # as exceptions are logged as warnings when voice modules are initialized
     try:
         API_KEYS.aws = AWSPollyKey.model_validate_json(
             (_kd / SETTINGS.AWSPOLLY_KEY_FILENAME).read_text().strip()
         )
     except Exception as err:
-        LOG.warning(
+        LOG.debug(
             "Could not load AWS Polly API key, ASR with AWS Polly will not work. Error: %s",
             err,
         )
@@ -187,7 +200,7 @@ else:
             (_kd / SETTINGS.AZURE_KEY_FILENAME).read_text().strip()
         )
     except Exception as err:
-        LOG.warning(
+        LOG.debug(
             "Could not load Azure API key, ASR with Azure will not work. Error: %s", err
         )
     try:
@@ -195,7 +208,7 @@ else:
             (_kd / SETTINGS.GOOGLE_KEY_FILENAME).read_text().strip()
         )
     except Exception as err:
-        LOG.warning(
+        LOG.debug(
             "Could not load Google API key, ASR with Google will not work. Error: %s",
             err,
         )

--- a/src/icespeak/voices/__init__.py
+++ b/src/icespeak/voices/__init__.py
@@ -27,7 +27,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Extra, Field
 
-from icespeak.settings import LOG, MAX_SPEED, MIN_SPEED, SETTINGS, TextFormatsT
+from icespeak.settings import LOG, MAX_SPEED, MIN_SPEED, SETTINGS, TextFormats
 from icespeak.transcribe import DefaultTranscriber
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class TTSOptions(BaseModel):
         le=MAX_SPEED,
         description="TTS speed.",
     )
-    text_format: TextFormatsT = Field(
+    text_format: TextFormats = Field(
         default=SETTINGS.DEFAULT_TEXT_FORMAT,
         description="Format of text (plaintext or SSML).",
     )


### PR DESCRIPTION
CLI interface now requires `cli` optional dependencies.

Install with
```sh
python3 -m pip install 'icespeak[cli]'
```
The typer library makes the code much simpler and the output is nicer.