### PR TITLE
Abbrev fix

### DIFF
--- a/src/icespeak/transcribe/__init__.py
+++ b/src/icespeak/transcribe/__init__.py
@@ -533,7 +533,7 @@ _IGNORED_TOKENS = frozenset(
     (TOK.WORD, TOK.PERSON, TOK.ENTITY, TOK.TIMESTAMP, TOK.UNKNOWN)
 )
 # These should not be interpreted as abbreviations
-# if they aren't followed by a period
+# unless they include a period
 _IGNORED_ABBREVS = frozenset(("mið", "fim", "bandar", "mao", "próf", "tom", "mar"))
 _HYPHEN_SYMBOLS = frozenset(HYPHENS)
 

--- a/src/icespeak/transcribe/__init__.py
+++ b/src/icespeak/transcribe/__init__.py
@@ -532,6 +532,9 @@ _SPORTS_LEMMAS: frozenset[str] = frozenset(("leikur", "vinna", "tapa", "sigra"))
 _IGNORED_TOKENS = frozenset(
     (TOK.WORD, TOK.PERSON, TOK.ENTITY, TOK.TIMESTAMP, TOK.UNKNOWN)
 )
+# These should not be interpreted as abbreviations
+# if they aren't followed by a period
+_IGNORED_ABBREVS = frozenset(("mið", "fim", "bandar", "mao", "próf", "tom", "mar"))
 _HYPHEN_SYMBOLS = frozenset(HYPHENS)
 
 _StrBool = Union[str, bool]
@@ -1379,6 +1382,7 @@ class DefaultTranscriber:
                 token.kind == TOK.WORD
                 and (meanings := Abbreviations.get_meaning(token.txt))
                 and meanings[0].fl != "erl"
+                and token.txt not in _IGNORED_ABBREVS
             ):
                 # Expand abbreviation
                 token.txt = meanings[0].stofn

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -464,6 +464,15 @@ def test_dt_token_transcribe_basic() -> None:
     t = _fix_ws("Hvað er 0,61cm í tommum?")
     n = DT.token_transcribe(t)
     assert "núll komma sextíu og einn sentimetri í tommum" in n
+    t = "En ef við tökum mið af því hve fim hún er í fimleikum?"
+    n = DT.token_transcribe(t)
+    assert n == t
+    t = "Hann bandar frá sér höndum þegar minnst er á mao zedong."
+    n = DT.token_transcribe(t)
+    assert n == t
+    t = "maðurinn tom fékk mar eftir strembið próf í síðustu viku"
+    n = DT.token_transcribe(t)
+    assert n == t
 
 
 def test_dt_token_transcribe_experimental():
@@ -543,7 +552,13 @@ def test_dt_token_transcribe_experimental():
     t = "Í 1., 2., 3. og 4. lagi. Í 31. lagi"
     n = DT.token_transcribe(t, options=t_opts)
     assert "Í fyrsta" in n
+    # TODO: Figure out a way to quickly put expanded word in correct case
     # assert "öðru" in n
     assert "þriðja" in n
     assert "fjórða" in n
     assert "þrítugasta og fyrsta" in n
+    t = "Á mið. eða fim. verður fundur hjá okkur."
+    n = DT.token_transcribe(t)
+    # TODO: ditto the point above
+    # assert "miðvikudag " in n
+    # assert "fimmtudag " in n

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -473,6 +473,12 @@ def test_dt_token_transcribe_basic() -> None:
     t = "maðurinn tom fékk mar eftir strembið próf í síðustu viku"
     n = DT.token_transcribe(t)
     assert n == t
+    t = "Undirritað, próf. Jónína"
+    n = DT.token_transcribe(t)
+    assert "prófessor" in n
+    t = "Hann er bandar. ríkisborgari"
+    n = DT.token_transcribe(t)
+    assert "bandarískur" in n
 
 
 def test_dt_token_transcribe_experimental():


### PR DESCRIPTION
TTS preprocessing was too heavy handed when expanding abbreviations, resulting in things like "mið" and "fim" being expanded into "miðvikudagur" and "fimmtudagur" in incorrect situations.

This PR implements a quick fix for this and also excludes some additional words (from `Abbrev.conf` in Tokenizer) that could be incorrectly marked as abbreviations.