### PR TITLE
OpenSSL 3.0.* support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
           echo '${{ secrets.AZURE_TTS_KEY }}' > keys/AzureSpeechServerKey.json
           # AWS Polly API key
           echo '${{ secrets.AWS_POLLY_KEY }}' > keys/AWSPollyServerKey.json
-          # Google TTS key
-          echo '${{ secrets.GOOGLE_TTS_KEY }}' > keys/GoogleServiceAccount.json
       - name: Test with pytest
         run: |
           pytest --run-slow -vvvrP --log-level=DEBUG --capture=tee-sys
@@ -60,8 +58,6 @@ jobs:
           echo '${{ secrets.AZURE_TTS_KEY }}' > keys/AzureSpeechServerKey.json
           # AWS Polly API key
           echo '${{ secrets.AWS_POLLY_KEY }}' > keys/AWSPollyServerKey.json
-          # Google TTS key
-          echo '${{ secrets.GOOGLE_TTS_KEY }}' > keys/GoogleServiceAccount.json
       - name: Test with pytest
         run: |
-          pytest --run-all -vvvrP --log-level=DEBUG --capture=tee-sys
+          pytest --run-all -vvvrP --log-level=INFO --capture=tee-sys

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,26 @@ jobs:
         run: |
           pre-commit run --all-files
 
+  network:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e '.[dev]'
+      - name: Set up API keys
+        run: |
+          # Azure TTS key
+          echo '${{ secrets.AZURE_TTS_KEY }}' > keys/AzureSpeechServerKey.json
+          # AWS Polly API key
+          echo '${{ secrets.AWS_POLLY_KEY }}' > keys/AWSPollyServerKey.json
+          # Google TTS key
+          echo '${{ secrets.GOOGLE_TTS_KEY }}' > keys/GoogleServiceAccount.json
+      - name: Test with pytest
+        run: |
+          pytest --run-all -vvvrP --log-level=DEBUG --capture=tee-sys

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,4 +60,4 @@ jobs:
           echo '${{ secrets.AWS_POLLY_KEY }}' > keys/AWSPollyServerKey.json
       - name: Test with pytest
         run: |
-          pytest --run-all -vvvrP --log-level=INFO --capture=tee-sys
+          pytest --run-all --log-level=INFO --capture=tee-sys

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Icespeak_ is a Python 3.9+ library that makes Icelandic-language speech synthes
 
 ## Local installation
 
-> _Note: The Azure TTS package currently only supports the very out-dated OpenSSL version 1.\*_
+> _Note: The Azure TTS package currently only supports OpenSSL version 3.0.\*_
 
 Clone the repository and cd into the folder.
 Then create and activate a virtual environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "reynir<4.0.0",
     "tokenizer<4.0.0",
     # Azure TTS
-    "azure-cognitiveservices-speech>=1.25.0",
+    "azure-cognitiveservices-speech>=1.38.0",
     # Google TTS
     #"google-cloud-texttospeech>=2.14.0",
     # AWS Polly TTS

--- a/src/icespeak/settings.py
+++ b/src/icespeak/settings.py
@@ -176,15 +176,18 @@ class Keys(BaseModel):
     def __hash__(self):
         return hash((self.azure, self.aws, self.google, self.tiro))
 
-    def __eq__(self, other):
-        if isinstance(other, Keys):
-            return (self.azure, self.aws, self.google, self.tiro) == (
-                other.azure,
-                other.aws,
-                other.google,
-                other.tiro,
-            )
-        return False
+    def __eq__(self, other: object):
+        return isinstance(other, Keys) and (
+            self.azure,
+            self.aws,
+            self.google,
+            self.tiro,
+        ) == (
+            other.azure,
+            other.aws,
+            other.google,
+            other.tiro,
+        )
 
 
 API_KEYS = Keys()

--- a/src/icespeak/voices/azure.py
+++ b/src/icespeak/voices/azure.py
@@ -164,11 +164,10 @@ class AzureVoice(BaseVoice):
 
     @override
     def load_api_keys(self):
-        if OPENSSL_VERSION_INFO[0] != 1:
-            # Azure only works with legacy OpenSSL
-            # See issues regarding compatibility with OpenSSL version >=3:
-            # https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1747
-            # https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1986
+        if not (OPENSSL_VERSION_INFO[0] == 3 and OPENSSL_VERSION_INFO[1] == 0):
+            # Azure only works with OpenSSL 3.0.*
+            # See issue:
+            # https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/2436
             _LOG.warning("OpenSSL version not compatible with Azure Cognitive Services, TTS might not work.")
 
         if API_KEYS.azure is None:
@@ -197,7 +196,7 @@ class AzureVoice(BaseVoice):
 
         outfile = SETTINGS.get_empty_file(options.audio_format)
         try:
-            audio_config = speechsdk.audio.AudioOutputConfig(filename=str(outfile))  # pyright: ignore[reportGeneralTypeIssues]
+            audio_config = speechsdk.audio.AudioOutputConfig(filename=str(outfile))  # pyright: ignore[reportArgumentType]
 
             # Init synthesizer
             synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_conf, audio_config=audio_config)


### PR DESCRIPTION
- Update `azure-cognitiveservices-speech` version to support OpenSSL 3.0.\*.
- Add network test to workflow. Runs on ubuntu-22.04 as it has OpenSSL version 3.0.\*.