### PR TITLE
Add support for OpenAI voices.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
   # Code linting & import sorting
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.5.7"
+    rev: "v0.6.4"
     hooks:
       # linter
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     # AWS Polly TTS
     "botocore>=1.21.40",
     "boto3>=1.18.40",
+    # OpenAI TTS
+    "openai>=1.44",
 ]
 
 [project.urls]

--- a/src/icespeak/settings.py
+++ b/src/icespeak/settings.py
@@ -232,8 +232,8 @@ else:
         )
     try:
         # First try to load the key from environment variable OPENAI_API_KEY
-        if os.getenv("OPENAI_API_KEY"):
-            API_KEYS.openai = OpenAIKey(api_key=SecretStr(str(os.getenv("OPENAI_API_KEY"))))
+        if key := os.getenv("OPENAI_API_KEY"):
+            API_KEYS.openai = OpenAIKey(api_key=SecretStr(key))
         else:
             API_KEYS.openai = OpenAIKey.model_validate_json((_kd / SETTINGS.OPENAI_KEY_FILENAME).read_text().strip())
     except Exception as err:

--- a/src/icespeak/tts.py
+++ b/src/icespeak/tts.py
@@ -39,7 +39,7 @@ from .settings import SETTINGS, TRACE, Keys
 from .transcribe import TranscriptionOptions
 
 # TODO: Re implement Tiro
-from .voices import BaseVoice, TTSOptions, VoiceInfoT, aws_polly, azure  # , google
+from .voices import BaseVoice, TTSOptions, VoiceInfoT, aws_polly, azure, openai  # , google
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -58,6 +58,7 @@ def _setup_voices() -> tuple[VoicesT, ServicesT]:
     services = (
         aws_polly.AWSPollyVoice(),
         azure.AzureVoice(),
+        openai.OpenAIVoice(),
         # google.GoogleVoice(),
         # tiro.TiroVoice(),
     )

--- a/src/icespeak/voices/__init__.py
+++ b/src/icespeak/voices/__init__.py
@@ -43,7 +43,7 @@ _LOG = getLogger(__name__)
 class VoiceInfoT(TypedDict):
     id: str
     lang: str
-    style: Literal["female", "male"]
+    style: Literal["female", "male", "neutral"]
     service: NotRequired[str]
 
 

--- a/src/icespeak/voices/openai.py
+++ b/src/icespeak/voices/openai.py
@@ -1,0 +1,103 @@
+"""
+
+Icespeak - Icelandic TTS library
+
+Copyright (C) 2024 Miðeind ehf.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+
+Icelandic-language text to speech via the Azure Speech API.
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing_extensions import override
+
+from logging import getLogger
+from pathlib import Path
+
+from openai import OpenAI
+
+from icespeak.settings import API_KEYS, SETTINGS, Keys
+
+from . import BaseVoice, ModuleAudioFormatsT, ModuleVoicesT, TTSOptions
+
+_LOG = getLogger(__name__)
+
+
+class OpenAIVoice(BaseVoice):
+    _NAME: str = "OpenAI"
+    _VOICES: ModuleVoicesT = {
+        "alloy": {"id": "alloy", "lang": "en-US", "style": "neutral"},
+        "echo": {"id": "echo", "lang": "en-US", "style": "male"},
+        "fable": {"id": "fable", "lang": "en-GB", "style": "male"},
+        "onyx": {"id": "onyx", "lang": "en-US", "style": "male"},
+        "nova": {"id": "nova", "lang": "en-US", "style": "female"},
+        "shimmer": {"id": "shimmer", "lang": "en-US", "style": "female"},
+    }
+    _AUDIO_FORMATS: ModuleAudioFormatsT = frozenset(("opus", "aac", "flac", "wav", "pcm"))
+
+    def _create_client(self, openai_key: str) -> OpenAI:
+        return OpenAI(api_key=openai_key)
+
+    @property
+    @override
+    def name(self) -> str:
+        return OpenAIVoice._NAME
+
+    @property
+    @override
+    def voices(self) -> ModuleVoicesT:
+        return OpenAIVoice._VOICES
+
+    @property
+    @override
+    def audio_formats(self) -> ModuleAudioFormatsT:
+        return OpenAIVoice._AUDIO_FORMATS
+
+    @override
+    def load_api_keys(self) -> None:
+        assert API_KEYS.openai, "OpenAI API key missing"
+
+        self._openai_client: Any = None
+        if self._openai_client is None:
+            self._openai_client = self._create_client(API_KEYS.openai.OPENAI_API_KEY.get_secret_value())
+
+    @override
+    def text_to_speech(self, text: str, options: TTSOptions, keys_override: Keys | None = None) -> Path:
+        if keys_override and keys_override.openai:
+            _LOG.debug("Using overridden OpenAI keys")
+            client = self._create_client(keys_override.openai.OPENAI_API_KEY.get_secret_value())
+        else:
+            _LOG.debug("Using default OpenAI keys")
+            client = self._openai_client
+
+        try:
+            openai_args = {
+                "model": "tts-1",  # TODO: add option of tts-1-hd model (slower, higher quality)
+                "voice": OpenAIVoice._VOICES[options.voice]["id"],
+                "input": text,
+                "response_format": options.audio_format,
+            }
+            _LOG.debug("Synthesizing with OpenAI: %s", openai_args)
+            with client.audio.speech.with_streaming_response.create(**openai_args) as response:
+                outfile = SETTINGS.get_empty_file(options.audio_format)
+                response.stream_to_file(outfile)
+        except Exception:
+            _LOG.exception("OpenAI TTS failed")
+            raise
+
+        return outfile

--- a/src/icespeak/voices/openai.py
+++ b/src/icespeak/voices/openai.py
@@ -23,17 +23,19 @@ Icelandic-language text to speech via the Azure Speech API.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from logging import getLogger
-from pathlib import Path
 
 from openai import OpenAI
 
 from icespeak.settings import API_KEYS, SETTINGS, Keys
 
 from . import BaseVoice, ModuleAudioFormatsT, ModuleVoicesT, TTSOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _LOG = getLogger(__name__)
 

--- a/src/icespeak/voices/openai.py
+++ b/src/icespeak/voices/openai.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see http://www.gnu.org/licenses/.
 
 
-Icelandic-language text to speech via the Azure Speech API.
+Icelandic-language text to speech via the OpenAI Speech API.
 
 """
 
@@ -50,7 +50,7 @@ class OpenAIVoice(BaseVoice):
         "nova": {"id": "nova", "lang": "en-US", "style": "female"},
         "shimmer": {"id": "shimmer", "lang": "en-US", "style": "female"},
     }
-    _AUDIO_FORMATS: ModuleAudioFormatsT = frozenset(("opus", "aac", "flac", "wav", "pcm"))
+    _AUDIO_FORMATS: ModuleAudioFormatsT = frozenset(("mp3", "opus", "aac", "flac", "wav", "pcm"))
 
     def _create_client(self, openai_key: str) -> OpenAI:
         return OpenAI(api_key=openai_key)
@@ -76,13 +76,13 @@ class OpenAIVoice(BaseVoice):
 
         self._openai_client: Any = None
         if self._openai_client is None:
-            self._openai_client = self._create_client(API_KEYS.openai.OPENAI_API_KEY.get_secret_value())
+            self._openai_client = self._create_client(API_KEYS.openai.api_key.get_secret_value())
 
     @override
     def text_to_speech(self, text: str, options: TTSOptions, keys_override: Keys | None = None) -> Path:
         if keys_override and keys_override.openai:
             _LOG.debug("Using overridden OpenAI keys")
-            client = self._create_client(keys_override.openai.OPENAI_API_KEY.get_secret_value())
+            client = self._create_client(keys_override.openai.api_key.get_secret_value())
         else:
             _LOG.debug("Using default OpenAI keys")
             client = self._openai_client

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -246,7 +246,7 @@ _ws_re = re.compile(r"\s\s+")
 _fix_ws: Callable[[str], str] = lambda t: _ws_re.sub(" ", t.strip())
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_dt_parser_transcribe() -> None:
     n = DT.parser_transcribe("þjálfari ÍR")
     assert "ÍR" not in n

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -56,7 +56,7 @@ _MIN_AUDIO_SIZE = 1000
 
 
 @pytest.mark.skipif(API_KEYS.aws is None, reason="Missing AWS Polly API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_AWSPolly_speech_synthesis():
     tts_out = tts_to_file(
         _TEXT,
@@ -69,7 +69,7 @@ def test_AWSPolly_speech_synthesis():
 
 
 @pytest.mark.skipif(API_KEYS.aws is None, reason="Missing AWS Polly API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_AWSPolly_speech_synthesis_with_keys_override():
     tts_out = tts_to_file(
         _TEXT,
@@ -83,7 +83,7 @@ def test_AWSPolly_speech_synthesis_with_keys_override():
 
 
 @pytest.mark.skipif(API_KEYS.azure is None, reason="Missing Azure API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_Azure_speech_synthesis():
     # Test Azure Cognitive Services
     tts_out = tts_to_file(
@@ -97,7 +97,7 @@ def test_Azure_speech_synthesis():
 
 
 @pytest.mark.skipif(API_KEYS.azure is None, reason="Missing Azure API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_Azure_speech_synthesis_with_keys_override():
     # Test Azure Cognitive Services
     tts_out = tts_to_file(
@@ -112,7 +112,7 @@ def test_Azure_speech_synthesis_with_keys_override():
 
 
 @pytest.mark.skipif(API_KEYS.google is None, reason="Missing Google API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_Google_speech_synthesis():
     # Test Google Cloud
     tts_out = tts_to_file(
@@ -126,7 +126,7 @@ def test_Google_speech_synthesis():
 
 
 @pytest.mark.skipif(condition=True, reason="Missing Tiro API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_Tiro_speech_synthesis():
     # Test Tiro
     tts_out = tts_to_file(
@@ -140,7 +140,7 @@ def test_Tiro_speech_synthesis():
 
 
 @pytest.mark.skipif(API_KEYS.openai is None, reason="Missing OpenAI API Key.")
-@pytest.mark.network()
+@pytest.mark.network
 def test_OpenAI_speech_synthesis():
     # Test OpenAI
     tts_out = tts_to_file(

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -139,6 +139,20 @@ def test_Tiro_speech_synthesis():
     path.unlink()
 
 
+@pytest.mark.skipif(API_KEYS.openai is None, reason="Missing OpenAI API Key.")
+@pytest.mark.network()
+def test_OpenAI_speech_synthesis():
+    # Test OpenAI
+    tts_out = tts_to_file(
+        _TEXT,
+        TTSOptions(text_format=TextFormats.TEXT, audio_format="pcm", voice="echo"),
+    )
+    path = tts_out.file
+    assert path.is_file(), "Expected audio file to exist"
+    assert path.stat().st_size > _MIN_AUDIO_SIZE, "Expected longer audio data"
+    path.unlink()
+
+
 @patch.dict(SERVICES, {"mock_service": MagicMock()})
 @patch.dict(VOICES, {"Dora": {"service": "mock_service"}})
 def test_keys_override_in_tts_to_file():


### PR DESCRIPTION
Note that OpenAI does not support mp4 format, currently set as the default format. It outputs audio with a sample rate of 24kHz, not 16kHz. TODO: add option to choose which model is used (currently two available).